### PR TITLE
docs: add seed feature documentation to user and dev guides

### DIFF
--- a/docs/guides/ai-mocker-dev-guide.md
+++ b/docs/guides/ai-mocker-dev-guide.md
@@ -24,6 +24,11 @@ packages/ai-mocker/
 │   ├── schema/
 │   │   ├── compliance.ts         # Ajv schema validation
 │   │   └── json-schema-to-zod.ts # Schema conversion utilities
+│   ├── seed/
+│   │   ├── index.ts              # Seed orchestrator (clear → check → plan → materialize)
+│   │   ├── planner.ts            # LLM-based scenario planner (structured output)
+│   │   ├── materializer.ts       # Persists plan steps with backdated timestamps
+│   │   └── types.ts              # SeedPlan, SeedConfig, SeedResult
 │   ├── util/
 │   │   ├── cache.ts              # LRU response cache
 │   │   ├── concurrency.ts        # ResourceMutex + LLM limiter
@@ -109,6 +114,37 @@ createAiPayloadGenerator()
 **Schema Sanitization** — Azure OpenAI's Structured Output mode enforces strict JSON Schema compliance. OpenAPI specs commonly include extensions like `xml`, `example`, and use `additionalProperties` freely. The `cleanForLlm()` function in `generator-agent.ts` recursively strips these before sending to the LLM. Ajv validation still uses the original schema.
 
 **`IOEither` → `TaskEither` Migration** — The original Prism mock pipeline was synchronous (`IOEither`). The AI mocker introduced async LLM calls, requiring an upgrade to `TaskEither` / `ReaderTaskEither` in the core factory. See `packages/core/src/factory.ts` line 65 and `packages/core/src/types.ts` line 53.
+
+### Scenario Seed Pipeline
+
+The seed pipeline runs **before** the HTTP server starts accepting traffic, pre-populating the memory database with coherent scenario data so the very first `GET` returns realistic results.
+
+```
+CLI (mock.ts)
+  └── createServer.ts
+        └── initializeAiMocker(operations, deps, config)
+              ├── 1. clearMemory?  → store.clearMemory()
+              ├── 2. idempotency   → skip if store.hasInteractions()
+              ├── 3. planSeed()    → LLM structured output → SeedPlan
+              └── 4. materializeSeed(plan)
+                    ├── resolvePlaceholders() → replace $id from prior steps
+                    ├── findOperationSchema() → match step to OpenAPI schema
+                    ├── generatorAgent()      → LLM generates response body
+                    └── store.store()         → persist with backdated timestamp
+```
+
+**Planner** (`seed/planner.ts`) — Sends the list of available API operations to the LLM via `withStructuredOutput` and receives a `SeedPlan` (3–8 ordered CRUD steps). The optional `scenariosContext` string is injected as a `## User Context` section in the system prompt, allowing users to steer the generated scenario (e.g. `"Swedish users"`).
+
+**Materializer** (`seed/materializer.ts`) — Iterates through the plan steps sequentially. For each step:
+1. Resolves `$id` placeholders using responses from prior steps (`dependsOnStep`)
+2. Finds the matching OpenAPI operation schema
+3. Calls `generatorAgent` to produce a schema-compliant response body
+4. Persists the interaction with a backdated timestamp (spread evenly over the last 24 hours so seed data ranks lower via recency decay)
+
+**CLI Wiring** — Three flags are defined in `packages/cli/src/commands/mock.ts` and threaded through `createServer.ts`:
+- `--scenarios-context` → `SeedConfig.scenariosContext`
+- `--clear-memory` → `SeedConfig.clearMemory`
+- `--no-seed` → skips the `initializeAiMocker()` call entirely
 
 ---
 

--- a/docs/guides/ai-mocker-user-guide.md
+++ b/docs/guides/ai-mocker-user-guide.md
@@ -55,11 +55,60 @@ curl -s http://localhost:4010/store/order/7 | jq
 | Flag | Description |
 |---|---|
 | `--ai` | Enable AI-powered response generation (requires LLM credentials) |
+| `--scenarios-context <text>` | Custom context prompt for AI seed generation (e.g. `"Swedish users"`) |
+| `--no-seed` | Skip AI scenario seeding on startup |
+| `--clear-memory` | Wipe existing AI memory before seeding |
 | `--port <n>` | Server port (default: `4010`) |
 | `--host <addr>` | Bind address (default: `127.0.0.1`; use `0.0.0.0` for Docker) |
 | `--dynamic` | Use dynamic faker generation as the fallback strategy |
 
 All standard Prism flags (`--cors`, `--errors`, `--verboseLevel`, etc.) work alongside `--ai`.
+
+---
+
+## Scenario Seeding
+
+When you launch Prism with `--ai`, the server automatically **pre-seeds** the memory database with a coherent set of CRUD interactions before it starts accepting traffic. This means your very first `GET` request can return realistic, inter-related data — no manual setup required.
+
+### How It Works
+
+1. The **Seed Planner** sends your API's endpoint list to the LLM and asks it to generate a realistic 3–8 step scenario (e.g. "create a user, then create two posts for that user").
+2. The **Seed Materializer** walks through the plan, generating schema-compliant response bodies for each step and persisting them to the memory database with backdated timestamps.
+3. Future requests leverage this seed data as context, producing responses consistent with the pre-seeded state.
+
+### Steering the Seed with `--scenarios-context`
+
+Pass a natural-language prompt to influence the kind of data the LLM generates:
+
+```bash
+# Seed with Swedish-themed data
+prism mock petstore.yaml --ai --scenarios-context "All users should have Swedish names and addresses"
+
+# Seed with an e-commerce scenario
+prism mock shop-api.yaml --ai --scenarios-context "Create a scenario with 3 products, 2 customers, and 1 order"
+```
+
+The context is injected into the planner's LLM prompt, so you can be as specific or general as you like.
+
+### Idempotency & Re-seeding
+
+Seeding is **idempotent** — if the database already contains interactions, seeding is skipped automatically. To force a re-seed:
+
+```bash
+# Wipe memory and re-seed
+prism mock spec.yaml --ai --clear-memory
+
+# Wipe and re-seed with new context
+prism mock spec.yaml --ai --clear-memory --scenarios-context "French bakery inventory"
+```
+
+### Skipping Seeding Entirely
+
+If you don't want any pre-populated data and prefer to start from a completely blank state:
+
+```bash
+prism mock spec.yaml --ai --no-seed
+```
 
 ---
 


### PR DESCRIPTION
Documents the AI seed pipeline (`--scenarios-context`, `--no-seed`, `--clear-memory`) in both guides.

### User Guide (`ai-mocker-user-guide.md`)
- Added three seed-related CLI flags to the options table
- Added new **Scenario Seeding** section covering how it works, `--scenarios-context` usage, idempotency & re-seeding, and `--no-seed`

### Dev Guide (`ai-mocker-dev-guide.md`)
- Added `seed/` directory entries to the package structure tree
- Added **Scenario Seed Pipeline** architecture subsection with flow diagram, planner/materializer details, and CLI wiring explanation

Closes #21